### PR TITLE
Call Resolver.query instead of Object.send

### DIFF
--- a/demo/check_soa.rb
+++ b/demo/check_soa.rb
@@ -68,7 +68,7 @@ ns_req.each_nameserver do |ns|
     # Get the SOA record.
     #----------------------------------------------------------------------
     
-    soa_req = res.send(domain, Net::DNS::SOA, Net::DNS::IN)
+    soa_req = res.query(domain, Net::DNS::SOA, Net::DNS::IN)
     
     if soa_req == nil
       puts res.errorstring, "\n"


### PR DESCRIPTION
Fixes issue with demo code:

```
(greg.poirier@oppie)(~/dev/ext/net-dns)(master)
bundle exec demo/check_soa.rb google.com
nspr002.va.opower.it. (10.20.48.51): demo/check_soa.rb:71:in `block (2 levels) in <main>': undefined method `google.com' for #<Net::DNS::Resolver:0x007fcba232f648> (NoMethodError)
```