### PR TITLE
Pull Request 1 net-dns2

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -970,7 +970,9 @@ module Net
 
         if not ans
           message = "No response from nameservers list"
-          @logger.fatal(message)
+          # NoMethodError: undefined method `fatal' for nil:NilClass
+          #@logger.fatal(message)
+          warn(message)
           raise NoResponseError, message
         end
 


### PR DESCRIPTION
Greetings.

Using net-dns2 in production revealed a couple of issues. Please be so kind as to consider my patches for your next release. Thank you.

Here's the first one: Resolver crashes e.g. on unreachable nameserver for want of logger.fatal. Replaced with warn(), didn't want to add another method.